### PR TITLE
docs: fix reference of openapi.yaml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ External dependencies:
 
 ## API Documentation
 
-The API is fully documented using the [OpenAPI standard](https://swagger.io/specification/). It's schema is located at [docs/openapi.yaml](docs/ai-agent-context.md).
+The API is fully documented using the [OpenAPI standard](https://swagger.io/specification/). It's schema is located at [docs/openapi.yaml](docs/openapi.yaml).
 
 ## Database
 


### PR DESCRIPTION
This PR fixes a reference in the README that should point to openapi.yaml file.